### PR TITLE
Just use https, now Flickr API use only https

### DIFF
--- a/flickr_photoset_downloader.php
+++ b/flickr_photoset_downloader.php
@@ -163,7 +163,7 @@ class flickr_api_wrapper{
 	 */
 	public static function call(Array $p){
 
-		$url = 'http://api.flickr.com/services/rest/';
+		$url = 'https://api.flickr.com/services/rest/';
 
 		if(empty($p['method'])){
 			throw new Exception('missing API method');


### PR DESCRIPTION
https://help.yahoo.com/kb/flickr/flickr-api-ssl-sln24319.html
